### PR TITLE
Ajusta validação do código de rastreio da jadlog

### DIFF
--- a/app/services/jadlog.rb
+++ b/app/services/jadlog.rb
@@ -35,7 +35,10 @@ class Jadlog
     }.fetch(status, 'exception')
   end
 
-  def self.validate_tracking_code(_shop, code)
+  def self.validate_tracking_code(shop, code)
+    return false unless shop
+    return false unless shop.jadlog_enabled
+
     code.match?(/^[0-9]{8,14}$/)
   end
 

--- a/spec/services/jadlog_spec.rb
+++ b/spec/services/jadlog_spec.rb
@@ -195,4 +195,48 @@ describe Jadlog do
       end
     end
   end
+
+  describe '#validate_tracking_code' do
+    context 'when shop is nil' do
+      it 'returns false' do
+        expect(
+          described_class.validate_tracking_code(nil, '123456')
+        ).to eq(false)
+      end
+    end
+
+    context 'when jadlog was disable' do
+      it 'returns false' do
+        expect(
+          described_class.validate_tracking_code(shop, '123456')
+        ).to eq(false)
+      end
+    end
+
+    context 'when jadlog was enable but code is invalid' do
+      before do
+        shop.jadlog_enabled = true
+        shop.save
+      end
+
+      it 'returns false' do
+        expect(
+          described_class.validate_tracking_code(shop, 'abc123467')
+        ).to eq(false)
+      end
+    end
+
+    context 'when jadlog was enable and code is valid' do
+      before do
+        shop.jadlog_enabled = true
+        shop.save
+      end
+
+      it 'returns true' do
+        expect(
+          described_class.validate_tracking_code(shop, '123456789')
+        ).to eq(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Link do trello: https://trello.com/c/Fzl6oBix

Esse ajuste foi feito na Jadlog, mas impacta a Loggi, pois ambas possui o mesmo tipo de código de rastreio e, dessa forma, o app estava identificando rastreios da Loggi como rastreio da Jadlog.