### PR TITLE
store all responses from Correios

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,8 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
 RSpec/ExampleLength:
   Enabled: false
+RSpec/MultipleExpectations:
+  Enabled: false
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'

--- a/app/models/correios_history.rb
+++ b/app/models/correios_history.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class CorreiosHistory < ApplicationRecord
+  validates :code, presence: true
+end

--- a/app/services/correios_html.rb
+++ b/app/services/correios_html.rb
@@ -32,6 +32,13 @@ class CorreiosHtml
     @events ||= {}
     @events[tracking_code] ||= begin
       response = request(tracking_code)
+
+      CorreiosHistory.create(
+        code: tracking_code,
+        response_body: response.body,
+        response_status: response.status
+      )
+
       parse(response.body)
     end
   end

--- a/db/migrate/20200818150116_create_correios_history.rb
+++ b/db/migrate/20200818150116_create_correios_history.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCorreiosHistory < ActiveRecord::Migration[5.2]
+  def change
+    create_table :correios_histories do |t|
+      t.string :code, null: false
+      t.text :response_body
+      t.integer :response_status
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_19_153810) do
+ActiveRecord::Schema.define(version: 2020_08_18_150116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "correios_histories", force: :cascade do |t|
+    t.string "code", null: false
+    t.text "response_body"
+    t.integer "response_status"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "shops", id: :serial, force: :cascade do |t|
     t.string "name"

--- a/spec/services/correios_html_spec.rb
+++ b/spec/services/correios_html_spec.rb
@@ -27,12 +27,19 @@ describe CorreiosHtml do
           .to_return(status: 200, body: html_with_events)
       end
 
-      it do
+      it 'returns last event' do
         expect(status).to eq(
           date: '27/08/2018 12:43 -3UTC'.to_datetime,
           status: 'delivered',
           message: 'Objeto entregue ao destinatário'
         )
+      end
+
+      it 'registers the history' do
+        status
+        expect(CorreiosHistory.last.code).to eq('OF526553827BR')
+        expect(CorreiosHistory.last.response_body).to eq(html_with_events)
+        expect(CorreiosHistory.last.response_status).to eq(200)
       end
     end
 
@@ -45,7 +52,16 @@ describe CorreiosHtml do
           .to_return(status: 200, body: html_without_events)
       end
 
-      it { is_expected.to eq(date: nil, status: 'pending', message: nil) }
+      it 'returns default event' do
+        expect(status).to eq(date: nil, status: 'pending', message: nil)
+      end
+
+      it 'registers the history' do
+        status
+        expect(CorreiosHistory.last.code).to eq('OF526556823BR')
+        expect(CorreiosHistory.last.response_body).to eq(html_without_events)
+        expect(CorreiosHistory.last.response_status).to eq(200)
+      end
     end
 
     context 'with an Excon error' do
@@ -53,7 +69,16 @@ describe CorreiosHtml do
 
       before { stub_request(:post, url).to_return(status: 500) }
 
-      it { is_expected.to eq(date: nil, status: 'pending', message: nil) }
+      it 'returns default event' do
+        expect(status).to eq(date: nil, status: 'pending', message: nil)
+      end
+
+      it 'registers the history' do
+        status
+        expect(CorreiosHistory.last.code).to eq('OF526556823BR')
+        expect(CorreiosHistory.last.response_body).to eq('')
+        expect(CorreiosHistory.last.response_status).to eq(500)
+      end
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/m1oIVAua

A ideia é armazenar as respostas da integração com Correios para demonstrar que eles cadastram eventos com data anterior.