### PR TITLE
Remove notification_url e refatora endpoints com a api_v2

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -3,7 +3,7 @@
 class Shop < ApplicationRecord
   has_many :trackings, dependent: :destroy
 
-  validates :slug, :name, :token, presence: true
+  validates :slug, :name, :token, :host, presence: true
 
   before_validation :default_token, :default_slug
 

--- a/app/services/vnda/api.rb
+++ b/app/services/vnda/api.rb
@@ -7,7 +7,7 @@ module Vnda
 
     def initialize(host)
       @host = host
-      @base_url = "#{API_SCHEME}://#{@host}"
+      @base_url = "#{API_SCHEME}://#{@host}/api/v2"
     end
 
     def get(endpoint, query = {})

--- a/app/services/vnda/notification_tracking.rb
+++ b/app/services/vnda/notification_tracking.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Vnda
+  class NotificationTracking
+    def initialize(shop)
+      @api = Vnda::Api.new(shop.host)
+    end
+
+    def dispatch(params)
+      @api.post(
+        '/notifications/trackings',
+        body: params.to_json,
+        expects: 200
+      )
+    end
+  end
+end

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -12,9 +12,9 @@
       </div>
 
       <div class="form-group">
-        <%= f.label :notification_url %><br>
-        <%= f.text_field :notification_url, class: 'form-control' %>
-        <small class="text-muted">Para a API-v2 é obrigatório HTTPS</small>
+        <%= f.label :host %><br>
+        <%= f.text_field :host, class: 'form-control' %>
+        <small class="text-muted">Informe apenas o host. Ex.: www.vnda.com.br</small>
       </div>
 
       <hr />

--- a/app/views/shops/show.html.erb
+++ b/app/views/shops/show.html.erb
@@ -14,8 +14,8 @@
   <dt class="col-sm-3">Token</dt>
   <dd class="col-sm-9"><%= @shop.token %></dd>
 
-  <dt class="col-sm-3">Notification URL</dt>
-  <dd class="col-sm-9"><%= @shop.notification_url %></dd>
+  <dt class="col-sm-3">Host da loja </dt>
+  <dd class="col-sm-9"><%= @shop.host %></dd>
 
   <dt class="col-sm-3">TNT habilitado</dt>
   <dd class="col-sm-9"><%= @shop.tnt_enabled %></dd>

--- a/app/workers/notify.rb
+++ b/app/workers/notify.rb
@@ -8,28 +8,16 @@ class Notify
 
   def perform(tracking_id)
     tracking = Tracking.find(tracking_id)
-    return false if tracking.shop.notification_url.blank?
+    shop = tracking.shop
 
-    res = send_notification(tracking.shop.notification_url, tracking.to_json)
+    response = Vnda::NotificationTracking.new(shop).dispatch(tracking)
 
     tracking.notifications.create(
-      url: tracking.shop.notification_url,
+      url: response.host,
       data: tracking.to_json,
-      response: res.body
+      response: response.body
     )
 
     true
-  end
-
-  private
-
-  def send_notification(url, json)
-    uri = URI(url)
-    api = Vnda::Api.new(uri.host)
-    api.post(
-      uri.path,
-      body: json,
-      expects: 200
-    )
   end
 end

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -247,6 +247,8 @@ pt-BR:
       shop: "Loja"
     attributes:
       shop:
+        host: "Host da loja"
+        name: "Nome da loja"
         mandae_pattern: Padrão para reconhecimento do rastreio (regex)
         loggi_token: 'Token'
         loggi_email: 'Email da conta'
@@ -263,4 +265,3 @@ pt-BR:
         updated_at: "Atualizado em"
         last_checkpoint_at: "Status checado em"
         package: Pacote
-

--- a/db/migrate/20200921201029_add_host_to_table_shop.rb
+++ b/db/migrate/20200921201029_add_host_to_table_shop.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddHostToTableShop < ActiveRecord::Migration[5.2]
+  def change
+    add_column :shops, :host, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_18_150116) do
+ActiveRecord::Schema.define(version: 2020_09_21_201029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2020_08_18_150116) do
     t.integer "loggi_shop_id"
     t.string "loggi_api_url"
     t.string "loggi_pattern"
+    t.string "host"
   end
 
   create_table "tracking_events", force: :cascade do |t|

--- a/lib/tasks/tracker.rake
+++ b/lib/tasks/tracker.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :tracker do
+  desc 'Extract host by notification_url field and fill shop host column'
+  task fill_shop_host_by_notification_url: :environment do
+    Shop.where(host: nil).each do |shop|
+      next if shop.notification_url.blank?
+
+      begin
+        host = URI(shop.notification_url).host
+      rescue URI::InvalidURIError
+        puts "Parser error(url): #{shop.notification_url}"
+        next
+      end
+
+      shop.host = host
+      shop.save
+    end
+  end
+end

--- a/spec/models/carrier_spec.rb
+++ b/spec/models/carrier_spec.rb
@@ -11,7 +11,7 @@ describe Carrier, type: :model do
     {
       'name': 'Shop 1',
       'token': 'shop1_token',
-      'notification_url': 'http://shop1.vnda.com.br',
+      'host': 'shop1.vnda.com.br',
       'tnt_email': '',
       'tnt_cnpj': '',
       'tnt_enabled': false,

--- a/spec/models/shop_spec.rb
+++ b/spec/models/shop_spec.rb
@@ -9,18 +9,33 @@ describe Shop, type: :model do
     let(:shop_attributes) do
       {
         token: 'shop1_token',
-        notification_url: 'http://shop1.vnda.com.br'
+        host: 'shop1.vnda.com.br'
       }
     end
 
-    it { expect { shop } .to raise_error(ActiveRecord::RecordInvalid) }
+    it 'raises error' do
+      expect { shop } .to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
+  context 'without host' do
+    let(:shop_attributes) do
+      {
+        name: 'Shop',
+        token: 'shop1_token'
+      }
+    end
+
+    it 'raises error' do
+      expect { shop } .to raise_error(ActiveRecord::RecordInvalid)
+    end
   end
 
   context 'without token' do
     let(:shop_attributes) do
       {
         name: 'Shop 1',
-        notification_url: 'http://shop1.vnda.com.br'
+        host: 'shop1.vnda.com.br'
       }
     end
 
@@ -33,13 +48,13 @@ describe Shop, type: :model do
       {
         name: 'Shop 1',
         token: 'shop1_token',
-        notification_url: 'http://shop1.vnda.com.br'
+        host: 'shop1.vnda.com.br'
       }
     end
 
     it { expect(shop.name).to eq('Shop 1') }
     it { expect(shop.token).to eq('shop1_token') }
     it { expect(shop.slug).to eq('shop-1') }
-    it { expect(shop.notification_url).to eq('http://shop1.vnda.com.br') }
+    it { expect(shop.host).to eq('shop1.vnda.com.br') }
   end
 end

--- a/spec/models/tracking/total_express_spec.rb
+++ b/spec/models/tracking/total_express_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tracking do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       total_enabled: true,
       total_client_id: '123',
       total_user: 'foo',

--- a/spec/models/tracking_event_spec.rb
+++ b/spec/models/tracking_event_spec.rb
@@ -7,7 +7,7 @@ describe TrackingEvent, type: :model do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br'
+      host: 'shop1.vnda.com.br'
     )
   end
 

--- a/spec/models/tracking_spec.rb
+++ b/spec/models/tracking_spec.rb
@@ -10,7 +10,7 @@ describe Tracking, type: :model do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       forward_to_intelipost: forward_to_intelipost
     )
   end

--- a/spec/requests/intelipost/create_spec.rb
+++ b/spec/requests/intelipost/create_spec.rb
@@ -10,7 +10,8 @@ describe 'Intelipost', type: :request do
       name: 'foo',
       token: 'a1b2c3d4e5',
       intelipost_id: 'abc',
-      intelipost_api_key: '12345'
+      intelipost_api_key: '12345',
+      host: 'shop1.vnda.com.br'
     )
   end
 

--- a/spec/requests/search/show_spec.rb
+++ b/spec/requests/search/show_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe 'Trackings', type: :request do
   subject(:response_content) { response.body }
 
-  let(:shop) { Shop.create!(name: 'A Mafalda', token: 'a1b2c3d4e5') }
+  let(:shop) do
+    Shop.create!(name: 'A Mafalda', token: 'a1b2c3d4e5', host: 'vnda.com.br')
+  end
 
   describe 'GET /:shop_name/:code' do
     it 'returns 404 without tracking' do

--- a/spec/requests/shops/index_spec.rb
+++ b/spec/requests/shops/index_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'GET /shops', type: :request do
 
   context 'with shops' do
     before do
-      Shop.create!(name: 'foo', token: 'a1b2c3d4e5')
-      Shop.create!(name: 'bar', token: '1a2b3c4d5e')
+      Shop.create!(name: 'foo', token: 'a1b2c3d4e5', host: 'vnda.com.br')
+      Shop.create!(name: 'bar', token: '1a2b3c4d5e', host: 'vnda.com.br')
     end
 
     it 'returns a list of shops with 2 shops' do

--- a/spec/requests/trakings/index_spec.rb
+++ b/spec/requests/trakings/index_spec.rb
@@ -5,7 +5,9 @@ require 'rails_helper'
 describe 'Trackings', type: :request do
   subject(:response_content) { response.body }
 
-  let(:shop) { Shop.create!(name: 'foo', token: 'a1b2c3d4e5') }
+  let(:shop) do
+    Shop.create!(name: 'foo', token: 'a1b2c3d4e5', host: 'vnda.com.br')
+  end
 
   before do
     allow(Sidekiq::ScheduledSet).to receive(:new).and_return([])

--- a/spec/services/carrier_url_spec.rb
+++ b/spec/services/carrier_url_spec.rb
@@ -11,7 +11,7 @@ describe CarrierURL do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       intelipost_api_key: 'foo',
       intelipost_id: '12345'
     )

--- a/spec/services/delivery_center_spec.rb
+++ b/spec/services/delivery_center_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DeliveryCenter do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       delivery_center_enabled: true,
       delivery_center_token: 'foo'
     )

--- a/spec/services/intelipost_spec.rb
+++ b/spec/services/intelipost_spec.rb
@@ -9,7 +9,7 @@ describe Intelipost do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       intelipost_api_key: 'foo'
     )
   end

--- a/spec/services/jadlog_spec.rb
+++ b/spec/services/jadlog_spec.rb
@@ -10,7 +10,7 @@ describe Jadlog do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       jadlog_password: 'foo'
     )
   end

--- a/spec/services/loggi_spec.rb
+++ b/spec/services/loggi_spec.rb
@@ -11,7 +11,7 @@ describe Loggi do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       loggi_enabled: true,
       loggi_token: '123',
       loggi_email: 'ajuda@vnda.com.br',

--- a/spec/services/mandae_spec.rb
+++ b/spec/services/mandae_spec.rb
@@ -11,7 +11,7 @@ describe Mandae do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       mandae_token: 'foo'
     )
   end

--- a/spec/services/total_express/api_spec.rb
+++ b/spec/services/total_express/api_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TotalExpress::Api do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       total_enabled: true,
       total_client_id: '123',
       total_user: 'foo',

--- a/spec/services/total_express/status_reader_spec.rb
+++ b/spec/services/total_express/status_reader_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TotalExpress::StatusReader do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       total_enabled: true,
       total_client_id: '123',
       total_user: 'foo',

--- a/spec/services/total_express/tracker_spec.rb
+++ b/spec/services/total_express/tracker_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TotalExpress::Tracker do
     Shop.create!(
       name: 'Shop 1',
       token: 'shop1_token',
-      notification_url: 'http://shop1.vnda.com.br',
+      host: 'shop1.vnda.com.br',
       total_enabled: true,
       total_client_id: '123',
       total_user: 'foo',

--- a/spec/services/vnda/api_spec.rb
+++ b/spec/services/vnda/api_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Vnda::Api do
   describe '#get' do
     subject(:result) { api.get(endpoint, query).body }
 
-    let(:endpoint) { '/api/v2/endpoint1' }
+    let(:endpoint) { '/endpoint1' }
     let(:query) { { arg1: 'value1' } }
 
     before do
@@ -35,7 +35,7 @@ RSpec.describe Vnda::Api do
   describe '#post' do
     subject(:result) { api.post(endpoint, body: body.to_json).body }
 
-    let(:endpoint) { '/api/v2/endpoint1' }
+    let(:endpoint) { '/endpoint1' }
     let(:body) { { arg1: 'value1' } }
 
     before do

--- a/spec/workers/notify_spec.rb
+++ b/spec/workers/notify_spec.rb
@@ -10,7 +10,7 @@ describe Notify do
   let(:shop) do
     Shop.create(
       name: 'foo',
-      notification_url: 'http://user:pass@foo.com/api/v2/notifications/trackings'
+      host: 'foo.com'
     )
   end
   let(:tracking) do
@@ -19,14 +19,6 @@ describe Notify do
       delivery_status: 'pending',
       shop: shop
     )
-  end
-
-  context 'without notfication url on shop' do
-    let(:shop) { Shop.create(name: 'foo') }
-
-    it 'does not send notification' do
-      expect(worker.perform(tracking.id)).to eq(false)
-    end
   end
 
   it 'sends notification' do

--- a/spec/workers/refresh_tracking_status_spec.rb
+++ b/spec/workers/refresh_tracking_status_spec.rb
@@ -10,7 +10,7 @@ describe RefreshTrackingStatus do
     Tracking.create!(
       code: 'PP423230351BR',
       delivery_status: delivery_status,
-      shop: Shop.create(name: 'foo')
+      shop: Shop.create(name: 'foo', host: 'foo.com')
     )
   end
 


### PR DESCRIPTION
https://trello.com/c/60gF3QmR

* Remove o campo ( notification_url ) da tela ( não removido do banco de dados porque precisa dele pra fazer a migração )
* Criado novo campo nas lojas ( api_url ) campo obrigatório no modelo
* Criado rake para extrair o Host do  notification_url: essa PR precisa da execução MANUAL do rake para funcionar corretamente: `rake tracker:fill_shop_api_url_by_notification_url`
* Adicionado nova coluna no Shop em todos os testes
* Refatorada a conexao com a api_v2 e o worker das notificações
