### PR TITLE
Corrige criação da url de rastreio da melhor envio

### DIFF
--- a/app/services/carrier_url.rb
+++ b/app/services/carrier_url.rb
@@ -50,10 +50,12 @@ class CarrierURL
   def tracking
     return if carrier != 'melhorenvio'
 
-    MelhorEnvio.new(@shop).melhorenvio_tracking(@code)
+    MelhorEnvio.new(shop).melhorenvio_tracking(code)
   end
 
   def format_url
+    return if carrier == 'melhorenvio' && tracking.blank?
+
     format(
       URLS[carrier],
       code: code,

--- a/app/services/melhor_envio.rb
+++ b/app/services/melhor_envio.rb
@@ -57,7 +57,7 @@ class MelhorEnvio
   def melhorenvio_tracking(tracking_code)
     response = request(tracking_code)
     event = parse(response, tracking_code)
-    event['melhorenvio_tracking']
+    event['tracking']
   end
 
   private

--- a/spec/services/carrier_url_spec.rb
+++ b/spec/services/carrier_url_spec.rb
@@ -89,12 +89,44 @@ describe CarrierURL do
           status: 200,
           body: {
             'A1B2C3D4E5' => {
-              'melhorenvio_tracking' => 'ME123456789BR'
+              'tracking' => 'ME123456789BR'
             }
           }.to_json
         )
 
       expect(url).to eq('https://melhorrastreio.com.br/rastreio/ME123456789BR')
+    end
+
+    it 'does not return URL without tracking code' do
+      stub_request(:get, 'http://shop1.vnda.com.br/api/v2/shop')
+        .to_return(
+          status: 200,
+          body: {
+            settings: {
+              melhor_envio_access_token: 'foo'
+            }
+          }.to_json
+        )
+
+      stub_request(:post, 'https://sandbox.melhorenvio.com.br/api/v2/me/shipment/tracking')
+        .with(
+          body: '{"orders":["A1B2C3D4E5"]}',
+          headers: {
+            'Authorization' => 'Bearer foo',
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json'
+          }
+        )
+        .to_return(
+          status: 200,
+          body: {
+            'A1B2C3D4E5' => {
+              'tracking' => ''
+            }
+          }.to_json
+        )
+
+      expect(url).to eq(nil)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/Iqi7b8Em

Alterado o campo do código de rastreio para o `tracking`

Também descobri que por conta do método `discover_tracker_url` depois que atribuímos algum valor no campo `self.tracker_url` ele não é mais atualizado devido ao `||=`, pensei em remover esse cara, mas ai deu problema nos testes da integração da intelipost ai resolvi tratar esse caso para só criar a URL quando o campo `tracking` existir no retorno da api da melhor envio.

Aqui também precisaria fazer uma correção talvez via console onde as URLs que hoje estão incompletas no `Tracking.tracker_url` nos rastreios da melhorenvio colocar `nil` no campo. Para quando houver as próximas atualizações de status atualizar o valor do campo `Tracking.tracker_url` se houver o código do `tracking`.