### PR TITLE
Altera o nível do log no ambiente de produção 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
Não tem PR.

Removido o debug que está gerando muito LOG e gera erro no Heroku: 
https://devcenter.heroku.com/articles/error-codes#l10-drain-buffer-overflow

` heroku[logplex]: Error L10 (output buffer overflow): drain 'd.6b8816e2-b94c-4dd3-858a-e98695b4718c' dropped 1 messages since 2020-12-28T19:25:46.850415+00:00.`
