### PR TITLE
 Evita erro na atualização de status quando o rastreamento não existe

### DIFF
--- a/app/workers/refresh_tracking_status.rb
+++ b/app/workers/refresh_tracking_status.rb
@@ -10,8 +10,10 @@ class RefreshTrackingStatus
     else
       schedule_next_checking(tracking)
     end
+  rescue ActiveRecord::RecordNotFound
+    logger.error("Tracking #{tracking_id} not found")
   rescue Carrier::UnsupportedCarrierError
-    logger.info("Tracking #{tracking.attributes} have an unsupported carrier")
+    logger.error("Tracking #{tracking.attributes} have an unsupported carrier")
   end
 
   protected

--- a/spec/workers/refresh_tracking_status_spec.rb
+++ b/spec/workers/refresh_tracking_status_spec.rb
@@ -109,12 +109,23 @@ describe RefreshTrackingStatus do
   end
 
   context 'with an unsupported carrier' do
-    it 'does not raises error' do
+    it 'does not raise error' do
       expect(Tracking).to receive(:find).with(tracking.id).and_return(tracking)
       expect(tracking).to receive(:update_status!)
         .and_raise(Carrier::UnsupportedCarrierError)
 
       subject.perform(tracking.id)
+    end
+  end
+
+  context 'with a deleted tracking' do
+    it 'does not raise error' do
+      expect(Tracking)
+        .to receive(:find)
+        .with(0)
+        .and_raise(ActiveRecord::RecordNotFound)
+
+      subject.perform(0)
     end
   end
 end


### PR DESCRIPTION
Não tem PR.

Adicionado tratamento no Worker para não gerar uma exception caso o ID do rastreamento não exista. A ideia é não gastar memória e processamento no sidekiq desnecessário.