### PR TITLE
Migra do HoneyBadger para o Sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,11 @@ jobs:
           name: Deploy to production
           command: |
             dpl --provider=heroku --app=vnda-tracker --api-key=$HEROKU_API_KEY
+      - run:
+          name: Set Sentry version
+          command: |
+            curl https://cli-assets.heroku.com/install.sh | sh
+            heroku config:set APP_REVISION=$CIRCLE_TAG -a vnda-tracker
 
 workflows:
   version: 2

--- a/.env.test
+++ b/.env.test
@@ -2,3 +2,4 @@ API_SCHEME="http"
 API_TOKEN="api_token"
 HTTP_USER=foo
 HTTP_PASSWORD=bar
+SENTRY_DSN=

--- a/Gemfile
+++ b/Gemfile
@@ -21,14 +21,15 @@ end
 
 gem 'bootsnap', require: false
 gem 'excon', '0.78.1'
-gem 'faraday', '0.15.4'
-gem 'faraday_middleware', '0.13.1'
-gem 'honeybadger', '3.3.1'
+gem 'faraday', '1.3.0'
+gem 'faraday_middleware', '1.0.0'
 gem 'nokogiri', '1.11.1'
 gem 'pg', '0.21.0'
 gem 'puma', '3.12.6'
 gem 'rails', '5.2.4.2'
 gem 'savon', '2.12.0'
+gem 'sentry-rails', '4.3.0'
+gem 'sentry-ruby', '4.3.0'
 gem 'sidekiq', '4.2.10'
 gem 'sinatra', require: nil
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,17 +80,19 @@ GEM
     execjs (2.7.0)
     faker (2.10.1)
       i18n (>= 1.6, < 2)
-    faraday (0.15.4)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.13.1)
-      faraday (>= 0.7.4, < 1.0)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.12.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     gyoku (1.3.1)
       builder (>= 2.1.2)
     hashdiff (1.0.1)
-    honeybadger (3.3.1)
     httpi (2.4.4)
       rack
       socksify
@@ -229,6 +231,16 @@ GEM
       nokogiri (>= 1.8.1)
       nori (~> 2.4)
       wasabi (~> 3.4)
+    sentry-rails (4.3.0)
+      rails (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.0)
+    sentry-ruby-core (4.3.0)
+      concurrent-ruby
+      faraday
     sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -285,9 +297,8 @@ DEPENDENCIES
   dotenv-rails
   excon (= 0.78.1)
   faker
-  faraday (= 0.15.4)
-  faraday_middleware (= 0.13.1)
-  honeybadger (= 3.3.1)
+  faraday (= 1.3.0)
+  faraday_middleware (= 1.0.0)
   jbuilder (~> 2.10)
   jquery-rails (= 4.3.1)
   nokogiri (= 1.11.1)
@@ -303,6 +314,8 @@ DEPENDENCIES
   rubocop-rspec (= 1.32.0)
   sass-rails (~> 5.0)
   savon (= 2.12.0)
+  sentry-rails (= 4.3.0)
+  sentry-ruby (= 4.3.0)
   sidekiq (= 4.2.10)
   simplecov (= 0.19.0)
   sinatra

--- a/app/models/tracking_event.rb
+++ b/app/models/tracking_event.rb
@@ -6,7 +6,7 @@ class TrackingEvent < ApplicationRecord
   validates :delivery_status, :tracking, presence: true
 
   def self.register(events, tracking)
-    Honeybadger.context(tracking: tracking.attributes, events: events)
+    Sentry.set_extras(tracking: tracking.attributes, events: events)
 
     events.each do |event|
       find_or_create_by!(

--- a/app/services/correios.rb
+++ b/app/services/correios.rb
@@ -14,8 +14,11 @@ class Correios
         'resultado' => 'U',
         'lingua' => '101',
         'objetos' => tracking_code)
-    rescue Wasabi::Resolver::HTTPError, Excon::Errors::Error => e
-      Honeybadger.notify(e)
+    rescue Wasabi::Resolver::HTTPError,
+           Excon::Errors::Error,
+           Savon::HTTPError => e
+      Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
+      return { date: nil, status: 'pending', message: nil }
     end
     object = response.body[:busca_eventos_response][:return][:objeto]
     event = object[:evento]

--- a/app/services/delivery_center.rb
+++ b/app/services/delivery_center.rb
@@ -10,8 +10,8 @@ class DeliveryCenter
 
   def status(tracking_code)
     response = request(tracking_code)
-    @last_response = response.body
-    event = parse(response.body)
+    @last_response = response.body if response
+    event = parse(response.body) if response&.body.present?
 
     return { date: nil, status: 'pending', message: nil } unless event
 
@@ -49,7 +49,7 @@ class DeliveryCenter
       }
     )
   rescue Excon::Errors::Error => e
-    Honeybadger.notify(e, context: { tracking_code: tracking_code })
+    Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
   end
 
   def parse(json)

--- a/app/services/jadlog.rb
+++ b/app/services/jadlog.rb
@@ -10,8 +10,8 @@ class Jadlog
 
   def status(tracking_code)
     response = request(tracking_code)
-    @last_response = response.body
-    event = parse(response.body)
+    @last_response = response.body if response
+    event = parse(response.body) if response&.body.present?
     return { date: nil, status: 'pending', message: nil } unless event
 
     {
@@ -54,7 +54,7 @@ class Jadlog
       body: { 'consulta' => [{ 'shipmentId' => tracking_code }] }.to_json
     )
   rescue Excon::Errors::Error => e
-    Honeybadger.notify(e, context: { tracking_code: tracking_code })
+    Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
   end
 
   def parse(json)

--- a/app/services/loggi.rb
+++ b/app/services/loggi.rb
@@ -39,9 +39,12 @@ class Loggi
       body: request_params(tracking_code).to_json
     )
 
+    return error_hash if response&.body.blank?
+
     parse(JSON.parse(response.body))
   rescue Excon::Errors::Error => e
-    Honeybadger.notify(e, context: { tracking_code: tracking_code })
+    Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
+    error_hash
   end
 
   def headers

--- a/app/services/mandae.rb
+++ b/app/services/mandae.rb
@@ -27,7 +27,7 @@ class Mandae
 
   def status(tracking_code)
     response = request(tracking_code)
-    event = parse(response)
+    event = parse(response) if response.present?
     unless event && event['date']
       return { date: nil, status: 'pending', message: nil }
     end
@@ -66,7 +66,7 @@ class Mandae
       }
     ).body
   rescue Excon::Errors::Error => e
-    Honeybadger.notify(e, context: { tracking_code: tracking_code })
+    Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
   end
 
   def parse(json)

--- a/app/services/melhor_envio.rb
+++ b/app/services/melhor_envio.rb
@@ -89,7 +89,7 @@ class MelhorEnvio
       headers: headers
     ).body
   rescue Excon::Errors::Error => exception
-    Honeybadger.notify(exception, context: { tracking_code: tracking_code })
+    Sentry.capture_exception(exception, extra: { tracking_code: tracking_code })
     { errors: 'exception' }.to_json
   end
 

--- a/app/services/postmon.rb
+++ b/app/services/postmon.rb
@@ -12,7 +12,7 @@ class Postmon
       hash = JSON.parse(response.body)
     rescue Excon::Errors::Error, JSON::ParserError => e
       hash = {}
-      Honeybadger.notify(e, context: { tracking_code: tracking_code })
+      Sentry.capture_exception(e, extra: { tracking_code: tracking_code })
     end
 
     last_event = hash['historico']&.last

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.release = ENV['APP_REVISION'] || 'dev'
+  config.enabled_environments = %w[development staging production]
+  config.environment = ENV['SENTRY_ENV'] || 'development'
+end

--- a/spec/services/correios_html_spec.rb
+++ b/spec/services/correios_html_spec.rb
@@ -64,7 +64,7 @@ describe CorreiosHtml do
       end
     end
 
-    context 'with an Excon error' do
+    context 'with an HTTP status error' do
       subject(:status) { correios.status('OF526556823BR') }
 
       before { stub_request(:post, url).to_return(status: 500) }
@@ -78,6 +78,25 @@ describe CorreiosHtml do
         expect(CorreiosHistory.last.code).to eq('OF526556823BR')
         expect(CorreiosHistory.last.response_body).to eq('')
         expect(CorreiosHistory.last.response_status).to eq(500)
+      end
+    end
+
+    context 'with a generic Excon error' do
+      subject(:status) { correios.status('OF526556823BR') }
+
+      before do
+        stub_request(:post, url).to_raise(Excon::Errors::Error, 'Error')
+      end
+
+      it 'returns default event' do
+        expect(status).to eq(date: nil, status: 'pending', message: nil)
+      end
+
+      it 'registers the history' do
+        status
+        expect(CorreiosHistory.last.code).to eq('OF526556823BR')
+        expect(CorreiosHistory.last.response_body).to eq('')
+        expect(CorreiosHistory.last.response_status).to eq(nil)
       end
     end
   end

--- a/spec/services/correios_spec.rb
+++ b/spec/services/correios_spec.rb
@@ -46,6 +46,43 @@ describe Correios do
         message: nil
       )
     end
+
+    context 'with HTTP error' do
+      before do
+        stub_request(
+          :post,
+          'http://webservice.correios.com.br/service/rastro'
+        ).with(body: request_xml).to_return(
+          status: 500,
+          body: xml_without_event
+        )
+      end
+
+      it 'returns pending' do
+        expect(correios.status('DW962413465BR')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
+
+    context 'with generic Excon error' do
+      before do
+        stub_request(
+          :post,
+          'http://webservice.correios.com.br/service/rastro'
+        ).with(body: request_xml).to_raise(Excon::Error)
+      end
+
+      it 'returns pending' do
+        expect(correios.status('DW962413465BR')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
   end
 
   describe '#events' do

--- a/spec/services/delivery_center_spec.rb
+++ b/spec/services/delivery_center_spec.rb
@@ -116,6 +116,48 @@ RSpec.describe DeliveryCenter do
         message: nil
       )
     end
+
+    context 'with HTTP error' do
+      before do
+        stub_request(:get, url)
+          .with(
+            headers: {
+              'Authorization' => 'Bearer foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_return(status: 500)
+      end
+
+      it 'returns pending' do
+        expect(delivery_center.status('S5A48')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
+
+    context 'with generic Excon error' do
+      before do
+        stub_request(:get, url)
+          .with(
+            headers: {
+              'Authorization' => 'Bearer foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_raise(Excon::Error)
+      end
+
+      it 'returns pending' do
+        expect(delivery_center.status('S5A48')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
   end
 
   describe '#last_response' do

--- a/spec/services/jadlog_spec.rb
+++ b/spec/services/jadlog_spec.rb
@@ -126,6 +126,54 @@ describe Jadlog do
         message: nil
       )
     end
+
+    context 'with HTTP error' do
+      before do
+        stub_request(:post, url)
+          .with(
+            body: {
+              'consulta' => [{ 'shipmentId' => '1800000000002' }]
+            }.to_json,
+            headers: {
+              'Authorization' => 'Bearer foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_return(status: 500)
+      end
+
+      it 'returns pending' do
+        expect(jadlog.status('1800000000002')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
+
+    context 'with generic Excon error' do
+      before do
+        stub_request(:post, url)
+          .with(
+            body: {
+              'consulta' => [{ 'shipmentId' => '1800000000002' }]
+            }.to_json,
+            headers: {
+              'Authorization' => 'Bearer foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_raise(Excon::Error)
+      end
+
+      it 'returns pending' do
+        expect(jadlog.status('1800000000002')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
   end
 
   describe '#events' do

--- a/spec/services/loggi_spec.rb
+++ b/spec/services/loggi_spec.rb
@@ -90,6 +90,50 @@ describe Loggi do
         message: nil
       )
     end
+
+    context 'with HTTP error' do
+      before do
+        stub_request(:post, 'https://staging.loggi.com/graphql')
+          .with(
+            body: body,
+            headers: {
+              'Authorization' => 'ApiKey ajuda@vnda.com.br:123',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_return(status: 500)
+      end
+
+      it 'returns pending' do
+        expect(loggi.status('123456')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
+
+    context 'with generic Excon error' do
+      before do
+        stub_request(:post, 'https://staging.loggi.com/graphql')
+          .with(
+            body: body,
+            headers: {
+              'Authorization' => 'ApiKey ajuda@vnda.com.br:123',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_raise(Excon::Error)
+      end
+
+      it 'returns pending' do
+        expect(loggi.status('123456')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
   end
 
   describe '#events' do

--- a/spec/services/mandae_spec.rb
+++ b/spec/services/mandae_spec.rb
@@ -132,6 +132,48 @@ describe Mandae do
         message: nil
       )
     end
+
+    context 'with HTTP error' do
+      before do
+        stub_request(:get, url)
+          .with(
+            headers: {
+              'Authorization' => 'foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_return(status: 500)
+      end
+
+      it 'returns pending' do
+        expect(mandae.status('134763521')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
+
+    context 'with generic Excon error' do
+      before do
+        stub_request(:get, url)
+          .with(
+            headers: {
+              'Authorization' => 'foo',
+              'Content-Type' => 'application/json'
+            }
+          )
+          .to_raise(Excon::Error)
+      end
+
+      it 'returns pending' do
+        expect(mandae.status('134763521')).to eq(
+          date: nil,
+          status: 'pending',
+          message: nil
+        )
+      end
+    end
   end
 
   describe '#events' do


### PR DESCRIPTION
<!--- Crie um título explicativo para o seu PR -->
https://trello.com/c/cbzQ5Xe2/11940-migrar-apps-para-do-honeybadger-para-o-sentry-tracker

## Descrição
Migra os envios de mensagens de erro do HoneyBadger para o Sentry.
Ajusta alguns comportamentos e testes para que erros no request sejam devidamente registrados pelo Sentry.
Altera a configuração do circleci para usar o Sentry
Nota: para usar a versão mais recente da gem do Sentry, foi necessário atualizar a gem Faraday.

## Motivação e contexto
Estamos começando a deixar de usar o HoneyBadger para centralizar todas as mensagens de erro no Sentry

## Como as modificações foram testadas?
Os testes foram feitos via rspec

## Categoria das modificações
<!--- Que tipo de modificação seu código introduz? Coloque um `x` em todos os boxes que se aplicam -->
- [ ] Bug fix (mudança que apenas corrige um bug e não quebra compatibilidade)
- [x] Nova feature (mudança que adiciona funcionalidade e não quebra compatibilidade)
- [ ] Breaking change (fix ou feature que faz com que a funcionalidade existente se comporte diferente do esperado)

## Checklist:
<!--- Coloque um `x` em todos os boxes que se aplicam -->
<!--- Se você não tem certeza sobre qualquer um dos pontos abaixo, não hesite em perguntar -->
- [x] Meu código segue o style guide do projeto
- [ ] Minha modificação requer mudanças na documentação
- [ ] Eu atualizei a documentação necessária
