### PR TITLE
Busca URL de rastreio pelo pacote para o Bling

### DIFF
--- a/app/models/tracking.rb
+++ b/app/models/tracking.rb
@@ -78,6 +78,10 @@ class Tracking < ApplicationRecord
   end
 
   def discover_tracker_url
+    if carrier == 'bling'
+      return self.tracker_url ||= Bling.new(shop).tracking_url(package)
+    end
+
     self.tracker_url ||= Carrier.url(
       carrier: carrier,
       code: code,

--- a/app/services/carrier_url.rb
+++ b/app/services/carrier_url.rb
@@ -2,7 +2,6 @@
 
 class CarrierURL
   URLS = {
-    'bling' => '',
     'correios' => 'https://track.aftership.com/brazil-correios/%<code>s',
     'intelipost' => 'https://status.ondeestameupedido.com/tracking/' \
       '%<intelipost_id>s/%<code>s',
@@ -30,7 +29,7 @@ class CarrierURL
   def fetch
     return '' unless URLS.key?(carrier)
 
-    tracking_url
+    format_url
   end
 
   private
@@ -49,30 +48,19 @@ class CarrierURL
   end
 
   def tracking
-    if carrier == 'melhorenvio'
-      return MelhorEnvio.new(shop).melhorenvio_tracking(code)
-    end
+    return if carrier != 'melhorenvio'
 
-    return Bling.new(shop).tracking_url(code) if carrier == 'bling'
-
-    nil
+    MelhorEnvio.new(shop).melhorenvio_tracking(code)
   end
 
-  def tracking_url
-    tracking_value = tracking
-    return tracking_value if carrier == 'bling'
+  def format_url
+    return if carrier == 'melhorenvio' && tracking.blank?
 
-    return if carrier == 'melhorenvio' && tracking_value.blank?
-
-    format_url(tracking_value)
-  end
-
-  def format_url(tracking_value)
     format(
       URLS[carrier],
       code: code,
       reid: client_id,
-      tracking: tracking_value,
+      tracking: tracking,
       invoice: code.to_s.gsub(/\D/, ''),
       intelipost_id: intelipost_id
     )

--- a/spec/models/tracking_spec.rb
+++ b/spec/models/tracking_spec.rb
@@ -64,6 +64,44 @@ describe Tracking, type: :model do
     end
   end
 
+  describe '#tracker_url' do
+    before do
+      allow(Carrier).to receive(:url).with(
+        carrier: carrier,
+        code: 'PM135787152BR',
+        shop: shop
+      ).and_return(
+        'www2.correios.com.br/sistemas/rastreamento?objetos=FEDCBA4321'
+      )
+    end
+
+    it 'sets the tracker url' do
+      expect(tracking.tracker_url).to eq(
+        'www2.correios.com.br/sistemas/rastreamento?objetos=FEDCBA4321'
+      )
+    end
+
+    context 'when shop is integrated with Bling' do
+      let(:carrier) { 'bling' }
+      let(:bling_service) { instance_double(Bling) }
+
+      before do
+        allow(Bling).to receive(:new).with(shop).and_return(bling_service)
+        allow(bling_service).to receive(:tracking_url)
+          .with('BBA1B3509E-01')
+          .and_return(
+            'www2.correios.com.br/sistemas/rastreamento?objetos=AB12345678'
+          )
+      end
+
+      it 'calls directly the Bling service to get the url' do
+        expect(tracking.tracker_url).to eq(
+          'www2.correios.com.br/sistemas/rastreamento?objetos=AB12345678'
+        )
+      end
+    end
+  end
+
   describe '#carrier' do
     context 'when tracking code is equal to order code' do
       subject(:tracking) { Tracking.new(tracking_attributes) }

--- a/spec/services/bling_spec.rb
+++ b/spec/services/bling_spec.rb
@@ -447,7 +447,7 @@ describe Bling do
       end
 
       it 'returns the tracking URL' do
-        expect(described_class.new(shop).tracking_url('AB123456789BR'))
+        expect(described_class.new(shop).tracking_url('ABCDE12345-01'))
           .to eq(
             'www2.correios.com.br/sistemas/rastreamento?objetos=AB12345678'
           )
@@ -463,7 +463,7 @@ describe Bling do
       end
 
       it 'returns nil' do
-        expect(described_class.new(shop).tracking_url('AB123456789BR'))
+        expect(described_class.new(shop).tracking_url('ABCDE12345-01'))
           .to be_nil
       end
     end
@@ -475,7 +475,7 @@ describe Bling do
       end
 
       it 'returns nil' do
-        expect(described_class.new(shop).tracking_url('AB123456789BR'))
+        expect(described_class.new(shop).tracking_url('ABCDE12345-01'))
           .to be_nil
       end
     end

--- a/spec/services/carrier_url_spec.rb
+++ b/spec/services/carrier_url_spec.rb
@@ -129,32 +129,4 @@ describe CarrierURL do
       expect(url).to eq(nil)
     end
   end
-
-  context 'with Bling' do
-    let(:carrier) { 'bling' }
-    let(:bling_service) { instance_double(Bling) }
-
-    before do
-      allow(Bling).to receive(:new).with(shop).and_return(bling_service)
-    end
-
-    it 'returns URL' do
-      allow(bling_service).to receive(:tracking_url).with('A1B2C3D4E5')
-        .and_return(
-          'www2.correios.com.br/sistemas/rastreamento?objetos=A1B2C3D4E5'
-        )
-
-      expect(url).to eq(
-        'www2.correios.com.br/sistemas/rastreamento?objetos=A1B2C3D4E5'
-      )
-    end
-
-    it 'does not return URL when response is nil' do
-      allow(bling_service).to receive(:tracking_url)
-        .with('A1B2C3D4E5')
-        .and_return(nil)
-
-      expect(url).to eq(nil)
-    end
-  end
 end


### PR DESCRIPTION
https://trello.com/c/RFPceawa/12442-bling-ajuste-tracking

## Descrição
Altera a função que busca a URL de rastreio para o Bling de modo a receber o código do pacote ao invés do código de rastreio. Passa a chamar no `tracking.rb` a função personalizada para o carrier Bling.
Reverte as alterações no `carrier_url.rb` feitas no PR #121 para obter a URL do Bling.

## Motivação e contexto
A função que busca a URL de rastreio do Bling precisa chamar o Bling a partir do número no Bling, obtido no Hub, sendo que para montar o request para o Hub é necessário obter o código do pacote. Para obter o código do pacote a partir do código de rastreio era necessário obter no banco o tracking a partir desta última informação, o que causava um erro na criação do rastreio, que busca a URL antes de validar (e consequentemente antes de criar). Por causa desse erro, os rastreios não estavam sendo criados para os pedidos do Bling.
Como não estamos mais usando o `carrier_url.rb` para os pedidos do Bling, as alterações feitas no mesmo foram desfeitas.

## Como as modificações foram testadas?
Os testes foram feitos via rspec e manualmente, chamando via postman o request de criação de tracking. 

## Categoria das modificações
<!--- Que tipo de modificação seu código introduz? Coloque um `x` em todos os boxes que se aplicam -->
- [x] Bug fix (mudança que apenas corrige um bug e não quebra compatibilidade)
- [ ] Nova feature (mudança que adiciona funcionalidade e não quebra compatibilidade)
- [ ] Breaking change (fix ou feature que faz com que a funcionalidade existente se comporte diferente do esperado)

## Checklist:
<!--- Coloque um `x` em todos os boxes que se aplicam -->
<!--- Se você não tem certeza sobre qualquer um dos pontos abaixo, não hesite em perguntar -->
- [x] Meu código segue o style guide do projeto
- [ ] Minha modificação requer mudanças na documentação
- [ ] Eu atualizei a documentação necessária
